### PR TITLE
Add LCSH block to subject

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -52,6 +52,8 @@
 		<meta property="term" refines="#subject-6">sh2008100157</meta>
 		<meta property="authority" refines="#subject-7">LCSH</meta>
 		<meta property="term" refines="#subject-7">sh2008108586</meta>
+		<meta property="authority" refines="#subject-8">LCSH</meta>
+		<meta property="term" refines="#subject-8">Unknown</meta>
 		<meta property="se:subject">Fiction</meta>
 		<meta id="collection" property="belongs-to-collection">Voyages Extraordinaires</meta>
 		<meta property="collection-type" refines="#collection">series</meta>


### PR DESCRIPTION
I couldn’t find “New Zealand -- Fiction” on LCSH, only “New Zealand fiction,” which is odd since “Australia -- Fiction” does exist. I think whoever set the subjects in PG must have noticed the same and mistakenly chose to make the names consistent.